### PR TITLE
Create README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Go	| [Upstream](https://github.com/golang/go), [RISC-V repository](https://githu
 Ocaml	| [Upstream](https://github.com/ocaml/ocaml), [RISC-V repository](https://github.com/nojb/riscv-ocaml)	| LGPL	| Nicolás Ojeda Bär
 Maxine VM (Java Virtual Machine)	| [Upstream](https://github.com/beehive-lab/Maxine-VM)	| GPLv2	| Maxine team
 Jikes RVM (Java Virtual Machine)	| [Upstream](https://github.com/JikesRVM/JikesRVM)	| Eclipse Public License (EPL)	| Martin Maas (University of California, Berkeley)
-OpenJDK/HotSpot (Java Virtual Machine)	| ?	| ?	| Alexey Baturo, Michael Knysnek, Martin Maas
+OpenJDK/HotSpot (Java Virtual Machine)	| [Upstream](https://github.com/openjdk/jdk), [RISC-V repository](https://github.com/openjdk/riscv-port/tree/riscv-port) | GPLv2 with Classpath Exception | [Felix Yang](mailto:felix.yang@huawei.com), [Yadong Wang](mailto:yadonn.wang@huawei.com)
 OpenJDK/OpenJ9 (Java Virtual Machine)	| [Upstream](https://github.com/eclipse/openj9)	| Eclipse Public License 2.0 (EPLv2) with ClassPath Exception & Apache 2.0	| [Cheng Jin](https://github.com/ChengJin01)
 BishengJDK/HotSpot (Java Virtual Machine)	| [Upstream](https://gitee.com/openeuler/bishengjdk-11/tree/risc-v)	| GPLv2 with Classpath Exception | [Yadong Wang](mailto:yadonn.wang@huawei.com)
 Free Pascal	| [Upstream](https://svn.freepascal.org/cgi-bin/viewvc.cgi/trunk/)	| ?	| Jeppe Johansen and others


### PR DESCRIPTION
Add OpenJDK to the RISC-V software list.
OpenJDK RISC-V port has been created officially and has its new repo, https://github.com/openjdk/riscv-port.
The project page can be seen here: https://openjdk.java.net/projects/riscv-port.
The JEP can be seen here: https://openjdk.java.net/jeps/8276797.